### PR TITLE
Add pre-commit to template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,4 +18,3 @@ repos:
       - id: cfn-python-lint
         name: AWS CloudFormation Linter
         files: \.(template)$
-        args: [--ignore-checks=W3002]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-json
+      - id: check-merge-conflict
+  - repo: https://github.com/awslabs/git-secrets
+    rev: 80230afa8c8bdeac766a0fece36f95ffaa0be778
+    hooks:
+      - id: git-secrets
+        entry: "git-secrets --scan"
+        files: "."
+  - repo: https://github.com/aws-cloudformation/cfn-python-lint
+    rev: v0.37.0
+    hooks:
+      - id: cfn-python-lint
+        name: AWS CloudFormation Linter
+        files: \.(template)$
+        args: [--ignore-checks=W3002]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 ## Reporting a Vulnerability
 
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security 
-via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/) or directly via email to aws-security@amazon.com. 
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security
+via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/) or directly via email to aws-security@amazon.com.
 Please do **not** create a public github issue.


### PR DESCRIPTION
*Issue #, if available:* N.A

*Description of changes:*
This PR proposes to add an unobtrusive [pre-commit](https://pre-commit.com/) base configuration file to this template repo. The pre-commit checks included in this configuration file would help improve both the quality and security posture of new repos. The change is "unobtrusive" since the repo-owner would need to install pre-commit for the configuration file to have any effect. They can also simply remove the file after provisioning, however it's presence encourages good security and software development practices.

The enabled pre-commit checks are:
- Trailing whitespace check (which identified an issue in `SECURITY.md`)
- Ensure files end in a newline and only a newline.
- Check JSON is well-formed
- Check no merge-conflict strings are present in files
- [git-secrets](https://github.com/awslabs/git-secrets)
- [cfn-lint](https://github.com/aws-cloudformation/cfn-python-lint)

Note that pre-commit is already in use on a number of AWS Labs and AWS Samples repos. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
